### PR TITLE
Properly test that multipreffer works across browser restarts.

### DIFF
--- a/test/functional/utils.js
+++ b/test/functional/utils.js
@@ -5,7 +5,10 @@
 require("geckodriver");
 
 const firefox = require("selenium-webdriver/firefox");
+const webdriver = require("selenium-webdriver");
+const cmd = require("selenium-webdriver/lib/command");
 const Context = firefox.Context;
+const path = require("path");
 
 // Preferences set during testing
 const FIREFOX_PREFERENCES = {
@@ -13,6 +16,9 @@ const FIREFOX_PREFERENCES = {
   "browser.tabs.remote.autostart": true,
   "browser.tabs.remote.autostart.1": true,
   "browser.tabs.remote.autostart.2": true,
+
+  "extensions.legacy.enabled": true,
+  "xpinstall.signatures.required": false,
 
   // Improve debugging using `browser toolbox`.
   "devtools.chrome.enabled": true,
@@ -91,6 +97,75 @@ async function removeCurrentTab(driver) {
   `);
 }
 
+async function restartDriverWithSameProfile(driver) {
+  const profile = (await driver.getCapabilities()).get("moz:profile");
+
+  // TODO glind, allow config to re-use profile
+  const options = new firefox.Options();
+  options.setProfile(profile);
+
+  const builder = new webdriver.Builder()
+    .forBrowser("firefox")
+    .setFirefoxOptions(options);
+
+  // Use standalone geckodriver server, launched by `npm-run-all -p test:func:*`
+  if (process.env.GECKODRIVER_URL) {
+    builder.usingServer(process.env.GECKODRIVER_URL);
+  }
+
+  const binaryLocation = process.env.FIREFOX_BINARY || "firefox";
+  await options.setBinary(new firefox.Binary(binaryLocation));
+  const driver2 = await builder.build();
+  // Firefox will be started up by now
+  driver2.setContext(Context.CHROME);
+  await driver.quit();
+  return driver2;
+}
+
+async function installAddon(driver, fileLocation) {
+  // references:
+  //    https://bugzilla.mozilla.org/show_bug.cgi?id=1298025
+  //    https://github.com/mozilla/geckodriver/releases/tag/v0.17.0
+  fileLocation =
+    fileLocation || path.join(process.cwd(), process.env.ADDON_ZIP);
+
+  const executor = driver.getExecutor();
+  executor.defineCommand(
+    "installAddon",
+    "POST",
+    "/session/:sessionId/moz/addon/install",
+  );
+  const installCmd = new cmd.Command("installAddon");
+
+  const session = await driver.getSession();
+  installCmd.setParameters({
+    sessionId: session.getId(),
+    path: fileLocation,
+    temporary: false,
+  });
+  const addonId = await executor.execute(installCmd);
+  console.log(
+    `Add-on at ${fileLocation} installed with (addonId: ${addonId})`,
+  );
+  return addonId;
+}
+
+async function uninstallAddon(driver, addonId) {
+  const executor = driver.getExecutor();
+  executor.defineCommand(
+    "uninstallAddon",
+    "POST",
+    "/session/:sessionId/moz/addon/uninstall",
+  );
+  const uninstallCmd = new cmd.Command("uninstallAddon");
+
+  const session = await driver.getSession();
+  uninstallCmd.setParameters({ sessionId: session.getId(), id: addonId });
+  await executor.execute(uninstallCmd);
+  console.log(`Add-on with id ${addonId} uninstalled`);
+}
+
+
 // What we expose to our add-on-specific tests
 module.exports = {
   FIREFOX_PREFERENCES,
@@ -105,4 +180,7 @@ module.exports = {
   prefHasUserValue,
   openNewTab,
   removeCurrentTab,
+  restartDriverWithSameProfile,
+  installAddon,
+  uninstallAddon,
 };

--- a/test/functional/utils.js
+++ b/test/functional/utils.js
@@ -100,7 +100,6 @@ async function removeCurrentTab(driver) {
 async function restartDriverWithSameProfile(driver) {
   const profile = (await driver.getCapabilities()).get("moz:profile");
 
-  // TODO glind, allow config to re-use profile
   const options = new firefox.Options();
   options.setProfile(profile);
 


### PR DESCRIPTION
Selenium doesn't have a direct way to restart the browser and keep using the same profile. And it doesn't help to pass a known path to the driver, because it creates a copy of the folder that is passed to it and uses the copy - so if you start with a profile path, and then try to restart with the same path, any changes made to the profile at runtime are lost.

I worked around this: it's possible to get the path of the *copy* that is being used, via the capabilities object. It's then possible to specify this path as the profile for a new instance - essentially a copy of the copy is created. This effectively emulates a restart.

Additionally, the shield addon utils version of `installAddon` installs the addon as temporary, so it doesn't persist restarts. I made a copy of that function which does *not* set the temporary flag, but this also meant adding `extensions.legacy.enabled=true` and `xpinstall.signatures.required=false` to our default set of preferences.