### PR TITLE
Touch only default branch prefs. This simplifies tests, cleanup, etc.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Multipreffer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2098,6 +2098,12 @@
       "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -2296,48 +2302,109 @@
       }
     },
     "eslint": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
-      "integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
+      "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
+        "ajv": "^6.9.1",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
+        "espree": "^5.0.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
+        "inquirer": "^6.2.2",
         "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^5.5.1",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
+        "table": "^5.2.3",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+          "dev": true,
+          "requires": {
+            "flatted": "^2.0.0",
+            "rimraf": "2.6.3",
+            "write": "1.0.3"
+          }
+        },
+        "write": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        }
       }
     },
     "eslint-import-resolver-node": {
@@ -2368,13 +2435,13 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "pkg-dir": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2395,21 +2462,21 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
+      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
       "dev": true,
       "requires": {
         "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.3.0",
+        "has": "^1.0.3",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "resolve": "^1.9.0"
       },
       "dependencies": {
         "debug": {
@@ -2440,9 +2507,9 @@
       }
     },
     "eslint-plugin-json": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.3.2.tgz",
-      "integrity": "sha512-WPdA8ph8ptdlPPta7se9zhhVKd3qGmeiNJkCi6hQi5xPXPEXkXkoNGAUjVD6EXN2Df3ded1ww4jXSn6+JA65fQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.4.0.tgz",
+      "integrity": "sha512-CECvgRAWtUzuepdlPWd+VA7fhyF9HT183pZnl8wQw5x699Mk/MbME/q8xtULBfooi3LUbj6fToieNmsvUcDxWA==",
       "dev": true,
       "requires": {
         "vscode-json-languageservice": "^3.2.1"
@@ -2825,14 +2892,22 @@
       "dev": true
     },
     "espree": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
+        "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -3288,6 +3363,12 @@
       "integrity": "sha512-qFlJnOBWDfIaunF54/lBqNKmXOI0HqNhu+mHkLmbaBXlS71PUd9OjFOdyevHt/aHoHB1+eW7eKHgRKOG5aHSpw==",
       "dev": true
     },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
     "fluent-syntax": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.7.0.tgz",
@@ -3527,9 +3608,9 @@
       }
     },
     "geckodriver": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.14.1.tgz",
-      "integrity": "sha512-4Lia4i5MGd7aLbgHXKAxjWxZ/HqwqX9fr7HfHLKKqRvF3jNzbO/FxnLUfcRKgdMSHXunRfgi/OxfdkHPMyUhnA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.16.0.tgz",
+      "integrity": "sha512-im4iInm9n3ntXlsmaoQx5wP1jMP40t+FQBbvlEr5jMCq3ruKcN60/kXn7eYNn0bchpgQf6nXVBy4p8SEaMpI4w==",
       "dev": true,
       "requires": {
         "adm-zip": "0.4.11",
@@ -4133,39 +4214,45 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-      "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
+        "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
+        "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
         "strip-ansi": "^5.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -4588,9 +4675,9 @@
       "dev": true
     },
     "jsonc-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.2.tgz",
-      "integrity": "sha512-TSU435K5tEKh3g7bam1AFf+uZrISheoDsLlpmAo6wWZYqjsnd09lHYK1Qo+moK4Ikifev1Gdpa69g4NELKnCrQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.3.tgz",
+      "integrity": "sha512-WJi9y9ABL01C8CxTKxRRQkkSpY/x2bo4Gy0WuiZGrInxQqgxQpvkBCLNcDYcHOSdhx4ODgbFcgAvfL49C+PHgQ==",
       "dev": true
     },
     "jsonfile": {
@@ -6158,12 +6245,23 @@
       }
     },
     "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
       }
     },
     "pluralize": {
@@ -6730,9 +6828,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -6929,8 +7027,8 @@
       "dev": true
     },
     "shield-studies-addon-utils": {
-      "version": "github:mozilla/shield-studies-addon-utils#b95492b008b335fa8bb01102b6fc6d38c6fb01ff",
-      "from": "github:mozilla/shield-studies-addon-utils#5.2.0",
+      "version": "github:mozilla/shield-studies-addon-utils#84647b48f8b85e46be277923a8db55ff1475b43c",
+      "from": "github:mozilla/shield-studies-addon-utils#5.2.1",
       "requires": {
         "ajv": "^6.5.0",
         "commander": "^2.15.1",
@@ -7103,9 +7201,9 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
-      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -7994,15 +8092,55 @@
       "dev": true
     },
     "table": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
-      "integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "dev": true,
       "requires": {
-        "ajv": "^6.6.1",
+        "ajv": "^6.9.1",
         "lodash": "^4.17.11",
-        "slice-ansi": "2.0.0",
-        "string-width": "^2.1.1"
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "tar": {
@@ -8537,9 +8675,9 @@
       "dev": true
     },
     "vscode-nls": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.0.0.tgz",
-      "integrity": "sha512-qCfdzcH+0LgQnBpZA53bA32kzp9rpq/f66Som577ObeuDlFIrtbEJ+A/+CCxjIh4G8dpJYNCKIsxpRAHIfsbNw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.0.tgz",
+      "integrity": "sha512-zKsFWVzL1wlCezgaI3XiN42IT8DIPM1Qr+G+RBhiU3U0bJCdC8pPELakRCtuVT4wF3gBZjBrUDQ8mowL7hmgwA==",
       "dev": true
     },
     "vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
   "name": "Multipreffer",
   "description": "Flippa lotta prefs",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "Mozilla",
   "bugs": {
     "url": ""
   },
   "dependencies": {
-    "shield-studies-addon-utils": "github:mozilla/shield-studies-addon-utils#5.2.0"
+    "shield-studies-addon-utils": "github:mozilla/shield-studies-addon-utils#5.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.0.1",
-    "eslint-plugin-import": "^2.5.0",
-    "eslint-plugin-json": "^1.2.0",
+    "eslint": "^5.15.3",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-json": "^1.4.0",
     "eslint-plugin-mozilla": "^0.14.0",
     "eslint-plugin-no-unsanitized": "^3.0.2",
-    "geckodriver": "^1.12.2",
+    "geckodriver": "^1.16.0",
     "mocha": "^5.2.0",
     "npm-run-all": "^4.1.1",
     "selenium-webdriver": "^3.5.0",
@@ -49,7 +49,7 @@
     "prewatch": "npm run bundle-utils",
     "sign": "echo 'TBD, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1407757'",
     "start": "web-ext run --no-reload",
-    "test": "ADDON_ZIP=./dist/multipreffer-1.0.zip mocha test/functional/ --bail",
+    "test": "ADDON_ZIP=./dist/multipreffer-2.0.zip mocha test/functional/ --bail",
     "watch": "web-ext run"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Multipreffer",
-  "version": "1.0",
+  "version": "2.0",
   "description": "Flippa lotta prefs",
   "background": {
     "scripts": ["background.js"]
@@ -9,7 +9,7 @@
   "applications": {
     "gecko": {
       "id": "multipreffer@shield.mozilla.org",
-      "strict_min_version": "64.0"
+      "strict_min_version": "66.0"
     }
   },
 

--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -10,14 +10,14 @@ ChromeUtils.defineModuleGetter(this, "AddonManager",
   "resource://gre/modules/AddonManager.jsm");
 ChromeUtils.defineModuleGetter(this, "Preferences",
   "resource://gre/modules/Preferences.jsm");
+const DefaultPreferences = new Preferences({ defaultBranch: true });
+
 
 let gExtension;
 
 this.multipreffer = class extends ExtensionAPI {
   getAPI(context) {
     gExtension = context.extension;
-    FirefoxHooks.init();
-
     return {
       multipreffer: {
         async studyReady(studyInfo) {
@@ -29,21 +29,9 @@ this.multipreffer = class extends ExtensionAPI {
 };
 
 this.FirefoxHooks = {
-  init() {
-    AddonManager.addAddonListener(this);
-  },
-
-  get abortedPref() {
-    return `extensions.multipreffer.${gExtension.id}.aborted`;
-  },
-
+  _oldDefaultValues: {},
   async studyReady(studyInfo) {
     // Called every time the add-on is loaded.
-    this.studyInfo = studyInfo;
-    if (Preferences.get(this.abortedPref)) {
-      return;
-    }
-
     try {
       const res = await fetch(gExtension.getURL("variations.json"));
       this.variations = await res.json();
@@ -53,56 +41,29 @@ this.FirefoxHooks = {
     }
 
     const variationName =
-      Preferences.get("extensions.multipreffer.test.variationName",
-                      this.studyInfo.variation.name);
+      Preferences.get(
+        "extensions.multipreffer.test.variationName", studyInfo.variation.name);
     const prefs = this.variations[variationName].prefs;
-    if (this.studyInfo.isFirstRun) {
-      for (const name of Object.keys(prefs.setValues)) {
-        if (!prefs.expectNonDefaults.includes(name) && Preferences.isSet(name)) {
-          // One of the prefs has a user-set value, ABORT!!!
-          // TODO: End the study/uninstall the addon?
-          Preferences.set(this.abortedPref, true);
-          return;
-        }
+
+    for (const pref of Object.keys(prefs)) {
+      let val = Preferences.get(pref);
+      if (val === undefined) {
+        // If undefined, save it as an empty string.
+        // This is the best we can do to reset it at cleanup
+        // since there's no way to clear the value of a pref
+        // on the default branch.
+        val = "";
       }
+      this._oldDefaultValues[pref] = val;
     }
-    Preferences.set(prefs.setValues);
+
+    DefaultPreferences.set(prefs);
+    AddonManager.addAddonListener(this);
   },
 
-  async cleanup() {
+  cleanup() {
     // Called when the add-on is being removed for any reason.
-    if (Preferences.get(this.abortedPref)) {
-      Preferences.reset(this.abortedPref);
-      return;
-    }
-
-    try {
-      const variationName = Preferences.get("extensions.multipreffer.test.variationName", this.studyInfo.variation.name);
-      const prefs = this.variations[variationName].prefs;
-      const setValues = prefs.setValues;
-
-      // Handle the prefs that need to be reset to default.
-      const resetDefaults = [];
-      for (const pref of prefs.resetDefaults) {
-        if (Preferences.get(pref) === setValues[pref]) {
-          // Pref value hasn't changed from what we set. Include it.
-          resetDefaults.push(pref);
-        }
-      }
-      Preferences.reset(resetDefaults);
-
-      // Handle the prefs that need to be set to a specified value.
-      const resetValues = prefs.resetValues;
-      for (const [name, value] of Object.entries(setValues)) {
-        if (Preferences.get(name) !== value) {
-          // Pref was modified. Make sure it's not in the resetValues list.
-          delete resetValues[name];
-        }
-      }
-      Preferences.set(resetValues);
-    } catch (e) {
-      Cu.reportError(e);
-    }
+    DefaultPreferences.set(this._oldDefaultValues);
   },
 
   onUninstalling(addon) {
@@ -117,7 +78,7 @@ this.FirefoxHooks = {
     if (addon.id !== gExtension.id) {
       return;
     }
-    await this.cleanup();
+    this.cleanup();
     AddonManager.removeAddonListener(this);
     // This is needed even for onUninstalling, because it nukes the addon
     // from UI. If we don't do this, the user has a chance to "undo".

--- a/src/variations.json
+++ b/src/variations.json
@@ -2,49 +2,16 @@
   "Control": {
     "weight": 1,
     "prefs": {
-      "setValues": {
-        "pref1": "string1",
-        "pref2": true,
-        "pref3": 99
-      },
-      "expectNonDefaults": ["pref2"],
-      "resetDefaults": ["pref1"],
-      "resetValues": {
-        "pref3": 100
-      }
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+      "network.cookie.cookieBehavior": 0
     }
   },
 
-  "Cohort1": {
+  "Experiment": {
     "weight": 1,
     "prefs": {
-      "setValues": {
-        "pref1": false,
-        "pref2": 999,
-        "pref3": "string2"
-      },
-      "expectNonDefaults": ["pref2", "pref3"],
-      "resetDefaults": ["pref1"],
-      "resetValues": {
-        "pref3": 1000
-      }
-    }
-  },
-
-  "Cohort2": {
-    "weight": 1,
-    "prefs": {
-      "setValues": {
-        "pref1": -100,
-        "pref2": "string3",
-        "pref3": true
-      },
-      "expectNonDefaults": [],
-      "resetDefaults": ["pref3"],
-      "resetValues": {
-        "pref1": "string99",
-        "pref2": false
-      }
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256,content-track-digest256",
+      "network.cookie.cookieBehavior": 4
     }
   }
 }

--- a/test/functional/all.js
+++ b/test/functional/all.js
@@ -8,241 +8,61 @@ const utils = require("./utils");
 const variations = require("../../src/variations.json");
 
 async function checkPrefs(driver, allPrefs, prefs) {
-  for (const pref of allPrefs) {
+  for (const pref of Object.keys(allPrefs)) {
     if (prefs[pref] !== undefined) {
       const val = await utils.getPreference(driver, pref);
       assert.equal(val, prefs[pref], `set the right pref for ${pref}`);
     } else {
-      const hasUserValue = await utils.prefHasUserValue(driver, pref);
-      assert.isFalse(hasUserValue, `${pref} is set to the default`);
+      const val = await utils.getPreference(driver, pref);
+      assert.equal(val, allPrefs[pref], `set the right pref for ${pref}`);
     }
   }
 }
 
 describe("setup and teardown", function() {
+  const SETUP_DELAY = 1000;
+  const RESTART_DELAY = 2000;
   // This gives Firefox time to start, and us a bit longer during some of the tests.
-  this.timeout(45000);
+  this.timeout(30000);
 
   let driver;
 
   describe("sets up the correct prefs, depending on the variation", function() {
-    const SETUP_DELAY = 500;
     let addonId;
 
     for (const variation in variations) {
       const prefs = variations[variation].prefs;
-      const allPrefs = Object.keys(prefs.setValues);
+      let allPrefs = {};
       describe(`sets the correct prefs for variation ${variation}`, () => {
         before(async () => {
           driver = await utils.setupWebdriver.promiseSetupDriver(
             utils.FIREFOX_PREFERENCES,
           );
           await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
+          allPrefs = {};
+          for (const pref of Object.keys(prefs)) {
+            allPrefs[pref] = await utils.getPreference(driver, pref);
+          }
           addonId = await utils.installAddon(driver);
           await driver.sleep(SETUP_DELAY);
         });
 
         it("has the correct prefs after install", async () => {
-          await checkPrefs(driver, allPrefs, prefs.setValues);
+          await checkPrefs(driver, allPrefs, prefs);
         });
 
         it("has the correct prefs after restart", async () => {
           driver = await utils.restartDriverWithSameProfile(driver);
-          await driver.sleep(SETUP_DELAY);
-          await checkPrefs(driver, allPrefs, prefs.setValues);
+          await driver.sleep(RESTART_DELAY);
+          await checkPrefs(driver, allPrefs, prefs);
         });
 
         it("has the correct prefs after uninstall", async () => {
           await utils.uninstallAddon(driver, addonId);
           await driver.sleep(SETUP_DELAY);
-          const prefsToCheck = Object.assign({}, prefs.setValues);
-          for (const pref of prefs.resetDefaults) {
+          const prefsToCheck = Object.assign({}, prefs);
+          for (const pref of Object.keys(prefs)) {
             prefsToCheck[pref] = undefined;
-          }
-          for (const pref in prefs.resetValues) {
-            prefsToCheck[pref] = prefs.resetValues[pref];
-          }
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        after(async () => {
-          await driver.quit();
-        });
-      });
-    }
-  });
-
-  describe("Check whether prefs user-modified after install are left user-modified after cleanup", function() {
-    const SETUP_DELAY = 500;
-    let addonId;
-
-    for (const variation in variations) {
-      const prefs = variations[variation].prefs;
-      const allPrefs = Object.keys(prefs.setValues);
-
-      const testPref = allPrefs[0];
-      const val = prefs.setValues[testPref];
-      let testVal;
-      if (typeof val === "number") {
-        testVal = 999;
-      } else if (typeof val === "string") {
-        testVal = "Test Value!";
-      } else if (typeof val === "boolean") {
-        testVal = true;
-      }
-
-      describe(`sets the correct prefs for variation ${variation}`, () => {
-        before(async () => {
-          driver = await utils.setupWebdriver.promiseSetupDriver(
-            utils.FIREFOX_PREFERENCES,
-          );
-          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          addonId = await utils.installAddon(driver);
-          await driver.sleep(SETUP_DELAY);
-        });
-
-        it("has the correct prefs after install", async () => {
-          await checkPrefs(driver, allPrefs, prefs.setValues);
-        });
-
-        it("has the correct prefs after restart", async () => {
-          driver = await utils.restartDriverWithSameProfile(driver);
-          await driver.sleep(SETUP_DELAY);
-          await checkPrefs(driver, allPrefs, prefs.setValues);
-        });
-
-        it("has the correct prefs after uninstall", async () => {
-          await utils.setPreference(driver, allPrefs[0], testVal);
-          await utils.uninstallAddon(driver, addonId);
-          const prefsToCheck = Object.assign({}, prefs.setValues);
-          for (const pref of prefs.resetDefaults) {
-            prefsToCheck[pref] = undefined;
-          }
-          for (const pref in prefs.resetValues) {
-            prefsToCheck[pref] = prefs.resetValues[pref];
-          }
-          prefsToCheck[testPref] = testVal;
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        after(async () => {
-          await driver.quit();
-        });
-      });
-    }
-  });
-
-  describe("Set up some prefs with unexpected values, ensure addon doesn't do anything", function() {
-    const SETUP_DELAY = 500;
-    let addonId;
-    let abortedPref;
-
-    for (const variation in variations) {
-      const prefs = variations[variation].prefs;
-      const allPrefs = Object.keys(prefs.setValues);
-
-      const testPref = allPrefs[0];
-      const testVal = "Test Value!";
-
-      describe(`no prefs should be set for ${variation}`, () => {
-        before(async () => {
-          driver = await utils.setupWebdriver.promiseSetupDriver(
-            utils.FIREFOX_PREFERENCES,
-          );
-          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          await utils.setPreference(driver, testPref, testVal);
-          addonId = await utils.installAddon(driver);
-          abortedPref = `extensions.multipreffer.${addonId}.aborted`;
-          await driver.sleep(SETUP_DELAY);
-        });
-
-        it("has the correct prefs after install", async () => {
-          // Take the first of the target prefs and set it to some value
-          // before installing the addon.
-          const prefsToCheck = {};
-          prefsToCheck[testPref] = testVal;
-          // The addon should set this pref to indicate that it aborted.
-          allPrefs.push(abortedPref);
-          prefsToCheck[abortedPref] = true;
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        it("has the correct prefs after restart", async () => {
-          driver = await utils.restartDriverWithSameProfile(driver);
-          await driver.sleep(SETUP_DELAY);
-          // Take the first of the target prefs and set it to some value
-          // before installing the addon.
-          const prefsToCheck = {};
-          prefsToCheck[testPref] = testVal;
-          prefsToCheck[abortedPref] = true;
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        it("has the correct prefs after uninstall", async () => {
-          const prefsToCheck = {};
-          prefsToCheck[testPref] = testVal;
-          await utils.uninstallAddon(driver, addonId);
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        after(async () => {
-          await driver.quit();
-        });
-      });
-    }
-  });
-
-  describe("Ensure expectNonDefaults works", function() {
-    const SETUP_DELAY = 500;
-    let addonId;
-
-    for (const variation in variations) {
-      const prefs = variations[variation].prefs;
-      if (!prefs.expectNonDefaults.length) {
-        continue;
-      }
-      const allPrefs = Object.keys(prefs.setValues);
-
-      const testPref = prefs.expectNonDefaults[0];
-      const val = prefs.setValues[testPref];
-      let testVal;
-      if (typeof val === "number") {
-        testVal = 999;
-      } else if (typeof val === "string") {
-        testVal = "Test Value!";
-      } else if (typeof val === "boolean") {
-        testVal = true;
-      }
-
-      describe(`sets the correct prefs for ${variation}`, () => {
-        before(async () => {
-          driver = await utils.setupWebdriver.promiseSetupDriver(
-            utils.FIREFOX_PREFERENCES,
-          );
-          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          await utils.setPreference(driver, testPref, testVal);
-          addonId = await utils.installAddon(driver);
-          await driver.sleep(SETUP_DELAY);
-        });
-
-        it("has the correct prefs after install", async () => {
-          await checkPrefs(driver, allPrefs, prefs.setValues);
-        });
-
-        it("has the correct prefs after restart", async () => {
-          driver = await utils.restartDriverWithSameProfile(driver);
-          await driver.sleep(SETUP_DELAY);
-          await checkPrefs(driver, allPrefs, prefs.setValues);
-        });
-
-        it("has the correct prefs after uninstall", async () => {
-          await utils.uninstallAddon(driver, addonId);
-          const prefsToCheck = Object.assign({}, prefs.setValues);
-          for (const pref of prefs.resetDefaults) {
-            prefsToCheck[pref] = undefined;
-          }
-          for (const pref in prefs.resetValues) {
-            prefsToCheck[pref] = prefs.resetValues[pref];
           }
           await checkPrefs(driver, allPrefs, prefsToCheck);
         });

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -13,7 +13,7 @@ const defaultConfig = {
     firefox: process.env.FIREFOX_BINARY || "firefox",
     browserConsole: false,
     startUrl: ["about:debugging"],
-    pref: [],
+    pref: ["extensions.multipreffer.test.variationName=Experiment"],
   },
 };
 


### PR DESCRIPTION
After all I've learned about default prefs in the last weeks, I think we should do this. The original requirements for this add-on are better met with default prefs. The limitation that they are set after a slight delay at startup is a limitation that consumers will have to work with.

This greatly simplifies tests and cleanup.

The cookie restrictions study should do its own handling of the cookieBehavior pref. I think it's a pretty bad idea to extend multipreffer to support expecting default values, etc just for that - it just makes everything complicated and difficult to spot bugs.