### PR TITLE
Don't uninstall when the add-on is disabled

### DIFF
--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -77,23 +77,11 @@ this.FirefoxHooks = {
     DefaultPreferences.set(this._oldDefaultValues);
   },
 
-  onUninstalling(addon) {
-    this.handleDisableOrUninstall(addon);
-  },
-
-  onDisabled(addon) {
-    this.handleDisableOrUninstall(addon);
-  },
-
-  async handleDisableOrUninstall(addon) {
+  async onUninstalling(addon) {
     if (addon.id !== gExtension.id) {
       return;
     }
-
     this.cleanup();
     AddonManager.removeAddonListener(this);
-    // This is needed even for onUninstalling, because it nukes the addon
-    // from UI. If we don't do this, the user has a chance to "undo".
-    addon.uninstall();
   },
 };

--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -77,11 +77,26 @@ this.FirefoxHooks = {
     DefaultPreferences.set(this._oldDefaultValues);
   },
 
-  async onUninstalling(addon) {
+  onUninstalling(addon) {
+    this.handleDisableOrUninstall(addon, { uninstall: true });
+  },
+
+  onDisabled(addon) {
+    this.handleDisableOrUninstall(addon, { uninstall: false });
+  },
+
+  async handleDisableOrUninstall(addon, { uninstall=false }={}) {
     if (addon.id !== gExtension.id) {
       return;
     }
+
     this.cleanup();
     AddonManager.removeAddonListener(this);
+
+    // This is needed even for onUninstalling, because it nukes the addon
+    // from UI. If we don't do this, the user has a chance to "undo".
+    if (uninstall) {
+      addon.uninstall();
+    }
   },
 };

--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -72,31 +72,27 @@ this.FirefoxHooks = {
     AddonManager.addAddonListener(this);
   },
 
+  /** Called when the add-on is being removed for any reason. */
   cleanup() {
-    // Called when the add-on is being removed for any reason.
     DefaultPreferences.set(this._oldDefaultValues);
+    AddonManager.removeAddonListener(this);
   },
 
   onUninstalling(addon) {
-    this.handleDisableOrUninstall(addon, { uninstall: true });
-  },
-
-  onDisabled(addon) {
-    this.handleDisableOrUninstall(addon, { uninstall: false });
-  },
-
-  async handleDisableOrUninstall(addon, { uninstall=false }={}) {
     if (addon.id !== gExtension.id) {
       return;
     }
-
     this.cleanup();
-    AddonManager.removeAddonListener(this);
 
-    // This is needed even for onUninstalling, because it nukes the addon
-    // from UI. If we don't do this, the user has a chance to "undo".
-    if (uninstall) {
-      addon.uninstall();
+    // This is needed because it nukes the addon from about:addons UI.
+    // If we don't do this, the user has a chance to "undo".
+    addon.uninstall();
+  },
+
+  onDisabled(addon) {
+    if (addon.id !== gExtension.id) {
+      return;
     }
+    this.cleanup();
   },
 };


### PR DESCRIPTION
Uninstall-on-disable is a behavior that made sense for studies that showed up in about:addons, before we could hide study add-ons. Nowadays, there is no user-accessible way outside of a browser console to disable a study. Further, none of the experiment automation tools disable add-ons. At the end of the study, the add-on is uninstalled. Leaving in uninstall-on-disable makes studies more fragile, and serves no useful function anymore.